### PR TITLE
OPSEXP-971 update RabbitMQ chart for K8S 1.20

### DIFF
--- a/helm/alfresco-process-application/README.md
+++ b/helm/alfresco-process-application/README.md
@@ -19,7 +19,7 @@ Kubernetes: `>=1.15.0-0`
 | https://activiti.github.io/activiti-cloud-helm-charts | alfresco-digital-workspace-app(common) | 7.1.0-M14 |
 | https://charts.bitnami.com/bitnami | kafka | 12.x.x |
 | https://charts.bitnami.com/bitnami | postgresql | 9.1.1 |
-| https://charts.bitnami.com/bitnami | rabbitmq | 7.8.0 |
+| https://charts.bitnami.com/bitnami | rabbitmq | 8.20.5 |
 
 ## Values
 

--- a/helm/alfresco-process-application/requirements.yaml
+++ b/helm/alfresco-process-application/requirements.yaml
@@ -9,7 +9,7 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     condition: application.postgresql.enabled,postgresql.enabled
   - name: rabbitmq
-    version: 7.8.0
+    version: 8.20.5
     repository: https://charts.bitnami.com/bitnami
     condition: application.rabbitmq.enabled,rabbitmq.enabled
   - name: common


### PR DESCRIPTION
Current RMQ chart is not compatible with k8s 1.20, this upgrades it to fix for AAE customers using thus chart

Ref. OPSEXP-971