### PR TITLE
CI: AAE-6772 stop building master branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 import:
-  - source: Alfresco/alfresco-build-tools:.travis.helm.yml@v1.1.6
-  - source: Alfresco/alfresco-build-tools:.travis.pre-commit.yml@v1.1.6
-  - source: Alfresco/alfresco-build-tools:.travis.helm-docs_install.yml@v1.1.6
-  - source: Alfresco/alfresco-build-tools:.travis.kubepug_install.yml@fix-kubepug-install
+  - source: Alfresco/alfresco-build-tools:.travis.helm.yml@v1.1.7
+  - source: Alfresco/alfresco-build-tools:.travis.pre-commit.yml@v1.1.7
+  - source: Alfresco/alfresco-build-tools:.travis.helm-docs_install.yml@v1.1.7
+  - source: Alfresco/alfresco-build-tools:.travis.kubepug_install.yml@v1.1.7
 
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,10 @@ import:
   - source: Alfresco/alfresco-build-tools:.travis.helm-docs_install.yml@v1.1.4
   - source: Alfresco/alfresco-build-tools:.travis.kubepug_install.yml@v1.1.4
 
+branches:
+  only:
+    - develop
+
 notifications:
   slack:
     rooms:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 import:
-  - source: Alfresco/alfresco-build-tools:.travis.helm.yml@v1.1.4
-  - source: Alfresco/alfresco-build-tools:.travis.pre-commit.yml@v1.1.4
-  - source: Alfresco/alfresco-build-tools:.travis.helm-docs_install.yml@v1.1.4
-  - source: Alfresco/alfresco-build-tools:.travis.kubepug_install.yml@v1.1.4
+  - source: Alfresco/alfresco-build-tools:.travis.helm.yml@v1.1.6
+  - source: Alfresco/alfresco-build-tools:.travis.pre-commit.yml@v1.1.6
+  - source: Alfresco/alfresco-build-tools:.travis.helm-docs_install.yml@v1.1.6
+  - source: Alfresco/alfresco-build-tools:.travis.kubepug_install.yml@v1.1.6
 
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ import:
   - source: Alfresco/alfresco-build-tools:.travis.helm.yml@v1.1.6
   - source: Alfresco/alfresco-build-tools:.travis.pre-commit.yml@v1.1.6
   - source: Alfresco/alfresco-build-tools:.travis.helm-docs_install.yml@v1.1.6
-  - source: Alfresco/alfresco-build-tools:.travis.kubepug_install.yml@v1.1.6
+  - source: Alfresco/alfresco-build-tools:.travis.kubepug_install.yml@fix-kubepug-install
 
 branches:
   only:


### PR DESCRIPTION
Main releases are handled inside alfresco-process-script which is already building and publishing the charts to the stable repository. Having the master branch running here is causing the override of the artifacts published by the release script.