### PR TITLE
AAE-9367 trigger auto-merge workflow on PR labeled only

### DIFF
--- a/.github/workflows/versions-propagation-auto-merge.yml
+++ b/.github/workflows/versions-propagation-auto-merge.yml
@@ -1,5 +1,9 @@
 name: Versions propagation auto-merge
-on: pull_request
+on:
+  pull_request:
+    types: [labeled]
+    branches:
+      - develop
 
 jobs:
   enable-auto-merge:


### PR DESCRIPTION
In some cases the label is not yet there when the workflow is triggered on PR opened
