### PR TITLE
AAE-10136: use helm package path instead of downloading it again

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,13 +65,9 @@ jobs:
 
       - name: Package Helm Chart
         id: package-helm-chart
-        uses: Alfresco/alfresco-build-tools/.github/actions/helm-package-chart@v1.20.1
+        uses: Alfresco/alfresco-build-tools/.github/actions/helm-package-chart@v1.20.3
         with:
           chart-dir: ${{ env.CHART_DIR }}
-
-      - uses: actions/download-artifact@v3
-        with:
-          name: ${{ steps.package-helm-chart.outputs.package-file }}
 
       - name: Get commit message
         id: get-commit-message
@@ -81,9 +77,9 @@ jobs:
           echo "message=$MSG" >> $GITHUB_OUTPUT
 
       - name: Publish Helm chart
-        uses: Alfresco/alfresco-build-tools/.github/actions/helm-publish-chart@v1.20.1
+        uses: Alfresco/alfresco-build-tools/.github/actions/helm-publish-chart@v1.20.3
         with:
-          chart-package: ${{ steps.package-helm-chart.outputs.package-file }}
+          chart-package: ${{ steps.package-helm-chart.outputs.package-file-path }}
           helm-charts-repo: ${{ env.HELM_REPO }}
           helm-charts-repo-branch: ${{ env.HELM_REPO_BRANCH }}
           helm-charts-repo-subfolder: ${{ env.HELM_REPO_SUBFOLDER }}


### PR DESCRIPTION
Benefits from fix at https://github.com/Alfresco/alfresco-build-tools/pull/168 and https://github.com/Alfresco/alfresco-build-tools/pull/171