### PR TITLE
AAE-38055 Update version of rabbimq used by activiti and alfresco charts

### DIFF
--- a/helm/alfresco-process-application/README.md
+++ b/helm/alfresco-process-application/README.md
@@ -155,6 +155,7 @@ Kubernetes: `>=1.15.0-0`
 | rabbitmq.enabled | bool | `true` |  |
 | rabbitmq.extraPlugins | string | `""` |  |
 | rabbitmq.fullnameOverride | string | `"rabbitmq"` |  |
+| rabbitmq.image.tag | string | `"3.13.7-debian-12-r4"` |  |
 | rabbitmq.ingress.enabled | bool | `false` |  |
 | rabbitmq.ingress.hostName | string | `"REPLACEME"` |  |
 | rabbitmq.ingress.path | string | `"/rabbitmq"` |  |

--- a/helm/alfresco-process-application/values.yaml
+++ b/helm/alfresco-process-application/values.yaml
@@ -346,6 +346,8 @@ postgresql:
   commonAnnotations:
     application: activiti
 rabbitmq:
+  image:
+    tag: "3.13.7-debian-12-r4"
   enabled: true
   fullnameOverride: rabbitmq
   extraPlugins: ""


### PR DESCRIPTION
Issue Link : https://hyland.atlassian.net/browse/AAE-38055