### PR TITLE
AAE-47094 Add Stale PR Cleanup workflow

### DIFF
--- a/.github/workflows/stale-pr-cleanup.yml
+++ b/.github/workflows/stale-pr-cleanup.yml
@@ -1,0 +1,14 @@
+name: Stale PR Cleanup
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+permissions:
+  pull-requests: write
+  issues: write
+
+jobs:
+  stale-pr-cleanup:
+    uses: Alfresco/alfresco-build-tools/.github/workflows/stale-pr-cleanup.yml@4e61fa01622e3f3a1898eb059d9a3af208897515 # v18.9.0


### PR DESCRIPTION
This PR adds the Stale PR Cleanup workflow to automatically manage stale pull requests.

## What does this workflow do?

- Runs daily via scheduled cron job (midnight UTC)
- Identifies and manages inactive pull requests
- Uses the shared workflow from `alfresco-build-tools`
- Can also be triggered manually via workflow_dispatch

## Why are we adding this?

This is part of standardizing PR hygiene across HxP repositories. The automated workflow helps:
- Keep the PR queue clean and manageable
- Reduce noise from abandoned PRs
- Ensure active PRs get proper attention
- Maintain consistent stale PR policies across all repos

## Source

The workflow references the shared implementation from:
`Alfresco/alfresco-build-tools/.github/workflows/stale-pr-cleanup.yml@4e61fa01622e3f3a1898eb059d9a3af208897515`